### PR TITLE
Cron scaler: clarify scale to 0

### DIFF
--- a/content/docs/1.4/scalers/postgresql.md
+++ b/content/docs/1.4/scalers/postgresql.md
@@ -40,7 +40,7 @@ triggers:
 - type: postgresql
   metadata:
     connection: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -57,7 +57,7 @@ triggers:
     port: "5432"
     dbName: postgresql
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -90,6 +90,6 @@ spec:
     - type: postgresql
       metadata:
         connection: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/1.5/scalers/cron.md
+++ b/content/docs/1.5/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,17 +49,26 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: cron-scaledobject
   namespace: default
 spec:
   scaleTargetRef:
-    deploymentName: my-deployment
+    name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/1.5/scalers/cron.md
+++ b/content/docs/1.5/scalers/cron.md
@@ -23,10 +23,10 @@ triggers:
 
 **Parameter list:**
 
-- `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found in: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+- `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/1.5/scalers/cron.md
+++ b/content/docs/1.5/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/1.5/scalers/postgresql.md
+++ b/content/docs/1.5/scalers/postgresql.md
@@ -40,7 +40,7 @@ triggers:
 - type: postgresql
   metadata:
     connection: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -57,7 +57,7 @@ triggers:
     port: "5432"
     dbName: postgresql
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -90,6 +90,6 @@ spec:
     - type: postgresql
       metadata:
         connection: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.0/scalers/cron.md
+++ b/content/docs/2.0/scalers/cron.md
@@ -26,7 +26,7 @@ triggers:
 - `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:
@@ -77,4 +81,3 @@ spec:
       end: 0 20 * * *
       desiredReplicas: "10"
 ```
-``

--- a/content/docs/2.0/scalers/cron.md
+++ b/content/docs/2.0/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -58,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:
@@ -66,3 +77,4 @@ spec:
       end: 0 20 * * *
       desiredReplicas: "10"
 ```
+``

--- a/content/docs/2.0/scalers/cron.md
+++ b/content/docs/2.0/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.0/scalers/postgresql.md
+++ b/content/docs/2.0/scalers/postgresql.md
@@ -38,7 +38,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -55,7 +55,7 @@ triggers:
     port: "5432"
     dbName: postgresql
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
 ```
 
@@ -88,6 +88,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.1/scalers/cron.md
+++ b/content/docs/2.1/scalers/cron.md
@@ -26,7 +26,7 @@ triggers:
 - `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.1/scalers/cron.md
+++ b/content/docs/2.1/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -58,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.1/scalers/cron.md
+++ b/content/docs/2.1/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.1/scalers/postgresql.md
+++ b/content/docs/2.1/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -93,6 +93,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.10/scalers/cron.md
+++ b/content/docs/2.10/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.10/scalers/cron.md
+++ b/content/docs/2.10/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.10/scalers/cron.md
+++ b/content/docs/2.10/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.10/scalers/etcd.md
+++ b/content/docs/2.10/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.10/scalers/postgresql.md
+++ b/content/docs/2.10/scalers/postgresql.md
@@ -42,7 +42,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
     metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. optional. Generated value would be `postgresql-postgresql---test@localhost`
@@ -61,7 +61,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
     metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -100,6 +100,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.11/scalers/cron.md
+++ b/content/docs/2.11/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.11/scalers/cron.md
+++ b/content/docs/2.11/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.11/scalers/cron.md
+++ b/content/docs/2.11/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.11/scalers/etcd.md
+++ b/content/docs/2.11/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.11/scalers/postgresql.md
+++ b/content/docs/2.11/scalers/postgresql.md
@@ -42,7 +42,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
     metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. optional. Generated value would be `postgresql-postgresql---test@localhost`
@@ -61,7 +61,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
     metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -100,6 +100,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.12/scalers/cron.md
+++ b/content/docs/2.12/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.12/scalers/cron.md
+++ b/content/docs/2.12/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.12/scalers/cron.md
+++ b/content/docs/2.12/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.12/scalers/etcd.md
+++ b/content/docs/2.12/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.12/scalers/postgresql.md
+++ b/content/docs/2.12/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
 ```
 
@@ -97,6 +97,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.13/scalers/cron.md
+++ b/content/docs/2.13/scalers/cron.md
@@ -49,7 +49,6 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-
 ### Scale to 0 during off hours
 
 If you want to scale you deployment to 0 outside office hours / working hours,

--- a/content/docs/2.13/scalers/cron.md
+++ b/content/docs/2.13/scalers/cron.md
@@ -49,7 +49,16 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +69,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.13/scalers/cron.md
+++ b/content/docs/2.13/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.13/scalers/cron.md
+++ b/content/docs/2.13/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.13/scalers/etcd.md
+++ b/content/docs/2.13/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.13/scalers/postgresql.md
+++ b/content/docs/2.13/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
 ```
 
@@ -97,6 +97,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.14/scalers/cron.md
+++ b/content/docs/2.14/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.14/scalers/cron.md
+++ b/content/docs/2.14/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.14/scalers/cron.md
+++ b/content/docs/2.14/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.14/scalers/etcd.md
+++ b/content/docs/2.14/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.14/scalers/postgresql.md
+++ b/content/docs/2.14/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
 ```
 
@@ -97,6 +97,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.2/scalers/cron.md
+++ b/content/docs/2.2/scalers/cron.md
@@ -26,7 +26,7 @@ triggers:
 - `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.2/scalers/cron.md
+++ b/content/docs/2.2/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -58,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.2/scalers/cron.md
+++ b/content/docs/2.2/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.2/scalers/postgresql.md
+++ b/content/docs/2.2/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -93,6 +93,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.3/scalers/cron.md
+++ b/content/docs/2.3/scalers/cron.md
@@ -26,7 +26,7 @@ triggers:
 - `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.3/scalers/cron.md
+++ b/content/docs/2.3/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -58,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.3/scalers/cron.md
+++ b/content/docs/2.3/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.3/scalers/postgresql.md
+++ b/content/docs/2.3/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -93,6 +93,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.4/scalers/cron.md
+++ b/content/docs/2.4/scalers/cron.md
@@ -26,7 +26,7 @@ triggers:
 - `timezone` - One of the acceptable values from the IANA Time Zone Database. The list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `start` - Cron expression indicating the start of the cron schedule.
 - `end` - Cron expression indicating the end of the cron schedule.
-- `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+- `desiredReplicas` - Number of replicas to which the resource has to be scaled **between the start and end** of the cron schedule.
 
 > 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
 
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.4/scalers/cron.md
+++ b/content/docs/2.4/scalers/cron.md
@@ -28,6 +28,8 @@ triggers:
 - `end` - Cron expression indicating the end of the cron schedule.
 - `desiredReplicas` - Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
 
+> 💡 **Note:** `start`/`end` support ["Linux format cron"](https://en.wikipedia.org/wiki/Cron) (Minute Hour Dom Month Dow).
+
 > **Notice:**
 > **Start and end should not be same.**
 >
@@ -47,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -58,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.4/scalers/cron.md
+++ b/content/docs/2.4/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -33,8 +33,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -62,7 +62,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.4/scalers/postgresql.md
+++ b/content/docs/2.4/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -93,6 +93,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.5/scalers/cron.md
+++ b/content/docs/2.5/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.5/scalers/cron.md
+++ b/content/docs/2.5/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.5/scalers/cron.md
+++ b/content/docs/2.5/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.5/scalers/postgresql.md
+++ b/content/docs/2.5/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -98,6 +98,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.6/scalers/cron.md
+++ b/content/docs/2.6/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.6/scalers/cron.md
+++ b/content/docs/2.6/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.6/scalers/cron.md
+++ b/content/docs/2.6/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.6/scalers/postgresql.md
+++ b/content/docs/2.6/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -98,6 +98,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.7/scalers/cron.md
+++ b/content/docs/2.7/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.7/scalers/cron.md
+++ b/content/docs/2.7/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.7/scalers/cron.md
+++ b/content/docs/2.7/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.7/scalers/postgresql.md
+++ b/content/docs/2.7/scalers/postgresql.md
@@ -41,7 +41,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
@@ -59,7 +59,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: 1
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -98,6 +98,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.8/scalers/cron.md
+++ b/content/docs/2.8/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.8/scalers/cron.md
+++ b/content/docs/2.8/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.8/scalers/cron.md
+++ b/content/docs/2.8/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.8/scalers/postgresql.md
+++ b/content/docs/2.8/scalers/postgresql.md
@@ -42,7 +42,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
@@ -61,7 +61,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -100,6 +100,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```

--- a/content/docs/2.9/scalers/cron.md
+++ b/content/docs/2.9/scalers/cron.md
@@ -49,7 +49,15 @@ When the time window starts, it will scale from the minimum number of replicas t
 
 What the CRON scaler does **not** do, is scale your workloads based on a recurring schedule.
 
-### Example
+### Scale to 0 during off hours
+
+If you want to scale you deployment to 0 outside office hours / working hours,
+you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
+replicas during work hours. That way the Deployment will be scaled to 0 ouside
+that time window. It's almost always an error to try to do the other way
+around, i.e. set `desiredReplicas: 0` in the cron trigger.
+
+#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -60,6 +68,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
+  minReplicaCount: 0,
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.9/scalers/cron.md
+++ b/content/docs/2.9/scalers/cron.md
@@ -54,10 +54,13 @@ What the CRON scaler does **not** do, is scale your workloads based on a recurri
 If you want to scale you deployment to 0 outside office hours / working hours,
 you need to set `minReplicaCount: 0` in the ScaledObject, and increase the
 replicas during work hours. That way the Deployment will be scaled to 0 ouside
-that time window. It's almost always an error to try to do the other way
+that time window. By default the ScaledObject `cooldownPeriod` is 5 minutes, so the actual
+scaling down will happen 5 minutes after the cron schedule `end` parameter.
+
+It's almost always an error to try to do the other way
 around, i.e. set `desiredReplicas: 0` in the cron trigger.
 
-#### Example that scales to 10 from 6AM to 8PM and to 0 otherwise
+#### Example: scale up to 10 replicas from 6AM to 8PM and scale down to 0 replicas otherwise
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -68,7 +71,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: my-deployment
-  minReplicaCount: 0,
+  minReplicaCount: 0
+  cooldownPeriod: 300
   triggers:
   - type: cron
     metadata:

--- a/content/docs/2.9/scalers/cron.md
+++ b/content/docs/2.9/scalers/cron.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     # Required
     timezone: Asia/Kolkata  # The acceptable values would be a value from the IANA Time Zone Database.
-    start: 30 * * * *       # Every hour on the 30th minute
-    end: 45 * * * *         # Every hour on the 45th minute
+    start: 0 6 * * *        # At 6:00 AM
+    end: 0 20 * * *         # At 8:00 PM
     desiredReplicas: "10"
 ```
 
@@ -35,8 +35,8 @@ triggers:
 >
 > For example, the following schedule is not valid:
 > ```yaml
-> start: 30 * * * *
-> end: 30 * * * *
+> start: 0 6 * * *        # At 6:00 AM
+> end: 0 6 * * *          # also at 6:00 AM
 >```
 
 ### How does it work?
@@ -64,7 +64,7 @@ spec:
   - type: cron
     metadata:
       timezone: Asia/Kolkata
-      start: 30 * * * *
-      end: 45 * * * *
+      start: 0 6 * * *
+      end: 0 20 * * *
       desiredReplicas: "10"
 ```

--- a/content/docs/2.9/scalers/etcd.md
+++ b/content/docs/2.9/scalers/etcd.md
@@ -37,7 +37,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by tls. It
 
 **TLS:**
 
-- `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `tls` - To enable SSL auth for etcd, set this to `enable`. If not set, TLS for etcd is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)

--- a/content/docs/2.9/scalers/postgresql.md
+++ b/content/docs/2.9/scalers/postgresql.md
@@ -42,7 +42,7 @@ triggers:
 - type: postgresql
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
@@ -61,7 +61,7 @@ triggers:
     port: "5432"
     dbName: test_db_name
     sslmode: disable
-    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+    query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
     targetQueryValue: "2.2"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
@@ -100,6 +100,6 @@ spec:
     - type: postgresql
       metadata:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued';"
         targetQueryValue: 1
 ```


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)


It has happened several times (#5585, #3609, #1759 and #2153) that
user tries to use cron scaler with `desiredReplicas` set to 0 and
it doesn't work as expected. This PR adds a note to the cron scaler
to clarify that is not the right approach.
